### PR TITLE
Fix searches with a space

### DIFF
--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -64,7 +64,7 @@ export const usePhotosSearch = (opts: Parameters<TPexelsClient['photos']['search
   const fetcher = async (_: string, pageIndex: number): Promise<FetcherDataType> => {
     const res = await pexelsClient.photos.search({
       page: pageIndex + 1,
-      query: encodeURIComponent(query),
+      query: query,
       orientation: orientation !== Orientation.ALL ? orientation : undefined,
       color: color !== ImageColor.ALL ? color : undefined,
     });


### PR DESCRIPTION
The search query was URL-encoded twice which made the search results worse. We can remove `encodeURIComponent` here because `pexelsClient.photos.search` already URL-encodes the search query.

Example:
<img width="460" alt="image" src="https://user-images.githubusercontent.com/1618488/174793517-60695e3c-9801-4621-82d6-d57ecfef7ec9.png">
